### PR TITLE
Loosen version check on JMS Serializer dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "guzzle/http": "~3.7",
-        "jms/serializer": "0.12.*",
+        "jms/serializer": "~0.12",
         "psr/log": "~1.0",
         "symfony/console": "~2.3",
         "symfony/expression-language": "~2.4"


### PR DESCRIPTION
The current `composer.json` file restricts `jms/serializer` to versions `0.12.*`.

Version `0.12.0` is 1year and 8 months, and 170 commits out of date, and as such, many other packages are requiring slightly newer versions of this bundle (for instance the FOSRestBundle), which makes using both of these packages impossible.