### PR TITLE
PHP7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "require": {
         "guzzle/http": "~3.7",
-        "jms/serializer": "0.12.*",
+        "jms/serializer": "~1.1",
         "psr/log": "~1.0",
-        "symfony/console": "~2.3",
-        "symfony/expression-language": "~2.4"
+        "symfony/console": "~2.8",
+        "symfony/expression-language": "~2.8"
     },
     "require-dev": {
         "guzzle/plugin-mock": "~3.4",


### PR DESCRIPTION
I had a problem on my test server with PHP7. When I launched php insight.phar analysis  --format=pmd > insight-pmd.xml, I had an error about not having opcache.load_comments=1
When I changed some lines in the composer.json of insight, it worked.