### PR TITLE
Configure with no interaction

### DIFF
--- a/Cli/Helper/ConfigurationHelper.php
+++ b/Cli/Helper/ConfigurationHelper.php
@@ -102,9 +102,9 @@ class ConfigurationHelper extends Helper
             $question = sprintf('What is your %s? ', $varname);
         }
 
-        $validator = function ($v) {
+        $validator = function ($v) use ($varname) {
             if (!$v) {
-                throw new \InvalidArgumentException('Your must answer this question.');
+                throw new \InvalidArgumentException(sprintf('Your must provide a %s!', $varname));
             }
 
             return $v;
@@ -112,7 +112,7 @@ class ConfigurationHelper extends Helper
 
         $dialog = $this->getHelperSet()->get('dialog');
 
-        return $dialog->askAndValidate($output, $question, $validator, false, $default);
+        return $dialog->askAndValidate($output, $question, $validator, ($input->isInteractive() ? false : 1), $default);
     }
 
     private function saveConfiguration(InputInterface $input, OutputInterface $output, Configuration $configuration)

--- a/Cli/Helper/ConfigurationHelper.php
+++ b/Cli/Helper/ConfigurationHelper.php
@@ -20,6 +20,18 @@ class ConfigurationHelper extends Helper
     {
         $configuration = new Configuration();
 
+        if ($apiToken = $input->getOption('api-token')) {
+            $configuration->setApiToken($apiToken);
+        }
+
+        if ($userUuid = $input->getOption('user-uuid')) {
+            $configuration->setUserUuid($userUuid);
+        }
+
+        if ($apiEndpoint = $input->getOption('api-endpoint')) {
+            $configuration->setApiEndpoint($apiEndpoint);
+        }
+
         $configuration->setUserUuid($this->askValue($input, $output, 'User Uuid', $configuration->getUserUuid()));
         $configuration->setApiToken($this->askValue($input, $output, 'Api Token', $configuration->getApiToken()));
         $configuration->setApiEndpoint($this->askValue($input, $output, 'Api Endpoint', $configuration->getApiEndpoint() ?: $this->apiEndpoint));
@@ -105,17 +117,13 @@ class ConfigurationHelper extends Helper
 
     private function saveConfiguration(InputInterface $input, OutputInterface $output, Configuration $configuration)
     {
-        if (!$input->isInteractive()) {
-            return;
-        }
-
         $question = 'Do you want to save this new configuration? [Y/n] ';
         if (PHP_VERSION_ID > 50400) {
             $question = json_encode($configuration->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n\n".$question;
         }
         $dialog = $this->getHelperSet()->get('dialog');
 
-        if ($dialog->askConfirmation($output, $question)) {
+        if ($dialog->askConfirmation($output, $question) or !$input->isInteractive()) {
             $configuration->save();
         }
     }


### PR DESCRIPTION
Solves #55 

- Enabled `--no-configuration` for `configure` command
- Read `--user-uuid` `--api-token` `--api-endpoint` from input options and set as default for asking them
- Removed infinite loop, when `-n` is set, but needed option is missing
