### PR TITLE
fix autoload dir when installed via composer

### DIFF
--- a/bin/insight
+++ b/bin/insight
@@ -11,7 +11,7 @@
  */
 
 // installed via composer?
-if (file_exists($a = __DIR__.'/../../../../../autoload.php')) {
+if (file_exists($a = __DIR__.'/../../../autoload.php')) {
     require_once $a;
 } else {
     require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
Ping @lyrixx 

The autoload dir wasn't correct (I tested it using `composer global require` and `composer require` inside a 2.* Symfony project). 