### PR TITLE
Avoid producing invalid xml output

### DIFF
--- a/Cli/Command/AnalyzeCommand.php
+++ b/Cli/Command/AnalyzeCommand.php
@@ -41,7 +41,7 @@ class AnalyzeCommand extends Command implements NeedConfigurationInterface
 
         $chars = array('-', '\\', '|', '/');
         $noAnsiStatus = 'Analysis queued';
-        $output->writeln($noAnsiStatus);
+        $output->getErrorOutput()->writeln($noAnsiStatus);
 
         $position = 0;
 


### PR DESCRIPTION
The change introduced in 5811f411e1a6e6a0eddf0c8cee8a37148190079d prepends 'Analysis queued' at the beginning of `stdout`. When piping this to a pmd file per the instructions at http://blog.insight.sensiolabs.com/2014/02/12/jenkins-integration.html invalid xml is produced.